### PR TITLE
fix: New packages to deal with chromedriver dist changes

### DIFF
--- a/Python/python_selenium/requirements.txt
+++ b/Python/python_selenium/requirements.txt
@@ -23,5 +23,5 @@ sortedcontainers==2.4.0
 trio==0.21.0
 trio-websocket==0.9.2
 urllib3==1.26.9
-webdriver-manager==3.7.0
+webdriver-manager==4.0.1
 wsproto==1.1.0

--- a/Ruby/selenium-rspec/Gemfile
+++ b/Ruby/selenium-rspec/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem 'webdrivers', '~> 5.0', require: false
+gem 'webdrivers', '~> 5.3', require: false
 gem "axe-devtools-selenium", '~> 4.4.0', :source => 'https://agora.dequecloud.com/artifactory/api/gems/devtools-gems'
 gem 'selenium-webdriver', '~> 4.3'
 gem "axe-devtools-rspec", '~> 4.4.0', :source => 'https://agora.dequecloud.com/artifactory/api/gems/devtools-gems'


### PR DESCRIPTION
Chromedriver > 114 moved, so these packages (for Ruby and Python) were upgraded to Chromedriver's new download location.

Java also needs an update, but the newer WebDriverManager requires Java 11, so that stopped me.

The Java sample also needed this change to work (due to a websocket error):

```java
import org.openqa.selenium.chrome.ChromeOptions;
...
public static void initiate_drivers() {
...
        ChromeOptions options = new ChromeOptions();
        options.addArguments("--remote-allow-origins=*");
        driver = new ChromeDriver(options);
...
```
Might want to upgrade Selenium instead:

(From Stack Overflow): The WebSocket issue is now fixed from selenium 4.8.2/4.8.3, there's no need to add "--remote-allow-origins=*" to the chrome options during invocation. Instead we can now directly update the selenium dependencies in our pom.xml.