### PR TITLE
fix(robot): do not call `create_reports()` on initialization of reporting class

### DIFF
--- a/Python/robot/tests/example_test.robot
+++ b/Python/robot/tests/example_test.robot
@@ -10,4 +10,3 @@ Axe Analyze
     Open Homepage and analyze for a11y issues
     Open the recipe card on the homepage and check for a11y issues
     [Teardown]    Close Browser
-

--- a/Python/robot/tests/reporting.py
+++ b/Python/robot/tests/reporting.py
@@ -29,14 +29,14 @@ class reporting:
         elif platform == "win32":
             reporter = root_path + "/resources/reporter-cli-win.exe"
         results_path = root_path + "/a11y-results"
-        jsonpath = root_path + "/axe-reports"
-        if not (os.path.isdir(jsonpath)):
-            os.mkdir(jsonpath)
-        command_html = str(reporter) + " " + jsonpath + " " + \
+        json_path = root_path + "/axe-reports"
+        if not (os.path.isdir(json_path)):
+            os.mkdir(json_path)
+        command_html = str(reporter) + " " + json_path + " " + \
             results_path+" --format html"
-        command_csv = str(reporter) + " " + jsonpath + \
+        command_csv = str(reporter) + " " + json_path + \
             " " + results_path + " --format csv"
-        command_xml = str(reporter) + " " + jsonpath + \
+        command_xml = str(reporter) + " " + json_path + \
             " " + results_path + " --format xml"
         try:
             os.system(command_html)

--- a/Python/robot/tests/reporting.py
+++ b/Python/robot/tests/reporting.py
@@ -2,38 +2,42 @@ import os
 import shutil
 from sys import platform
 
+
 class reporting:
 
     def __init__(self):
-        self.create_reports()
-
+        # Does not require any initialization
+        pass
 
     def get_relative_path(self):
         absolute_path_to_proj = os.getcwd()
         path = absolute_path_to_proj.split(" ")
-        pathlist = path[0].split("/")
-        requiredpath = ""
-        for string in pathlist:
-            requiredpath = requiredpath+"/"+string
+        path_list = path[0].split("/")
+        required_path = ""
+        for string in path_list:
+            required_path = required_path + "/" + string
             if string == 'robot':
                 break
-        return requiredpath
+        return required_path
 
     def create_reports(self):
-        rootpath=self.get_relative_path()
+        root_path = self.get_relative_path()
         if platform == "linux" or platform == "linux2":
-            reporter = rootpath+"/resources/reporter-cli-linux"
+            reporter = root_path+"/resources/reporter-cli-linux"
         elif platform == "darwin":
-            reporter = rootpath+"/resources/reporter-cli-macos"
+            reporter = root_path + "/resources/reporter-cli-macos"
         elif platform == "win32":
-            reporter = rootpath+"/resources/reporter-cli-win.exe"
-        resultspath = rootpath+"/a11y-results"
-        jsonpath = rootpath + "/axe-reports"
+            reporter = root_path + "/resources/reporter-cli-win.exe"
+        results_path = root_path + "/a11y-results"
+        jsonpath = root_path + "/axe-reports"
         if not (os.path.isdir(jsonpath)):
             os.mkdir(jsonpath)
-        command_html = str(reporter) +" "+jsonpath+" "+resultspath+" --format html"
-        command_csv = str(reporter) +" "+jsonpath+" "+resultspath+" --format csv"
-        command_xml = str(reporter) +" "+jsonpath+" "+resultspath+" --format xml"
+        command_html = str(reporter) + " " + jsonpath + " " + \
+            results_path+" --format html"
+        command_csv = str(reporter) + " " + jsonpath + \
+            " " + results_path + " --format csv"
+        command_xml = str(reporter) + " " + jsonpath + \
+            " " + results_path + " --format xml"
         try:
             os.system(command_html)
             os.system(command_csv)
@@ -42,10 +46,7 @@ class reporting:
             return ("reporter binary is not present")
 
     def clear_reports(self):
-        rootpath=self.get_relative_path()
-        if not (os.path.isdir(rootpath+"/axe-reports/")):
-            os.mkdir(rootpath+"/axe-reports/")
-        shutil.rmtree(rootpath+"/axe-reports/")
-
-if __name__ == "__main__":
-    reporting()
+        root_path = self.get_relative_path()
+        if not (os.path.isdir(root_path + "/axe-reports/")):
+            os.mkdir(root_path + "/axe-reports/")
+        shutil.rmtree(root_path + "/axe-reports/")

--- a/Python/robot/tests/resource.robot
+++ b/Python/robot/tests/resource.robot
@@ -12,7 +12,7 @@ ${HOMEPAGE URL}      https://broken-workshop.dequelabs.com/
 
 *** Keywords ***
 Open Homepage and analyze for a11y issues
-    clear reports
+    Clear Reports
     Open Browser    ${HOMEPAGE URL}    ${BROWSER}
     Maximize Browser Window
     Set Selenium Speed    ${DELAY}
@@ -21,7 +21,4 @@ Open Homepage and analyze for a11y issues
 Open the recipe card on the homepage and check for a11y issues
     Click element    css:#main-content > div.Recipes > div:nth-child(1) > div.Recipes__card-foot > button
     audit_for_accessibility
-    create reports
-
-
-
+    Create Reports


### PR DESCRIPTION
When running the robot framework we should not call `create_reports()` on initialization since it will run it as soon as we execute the robot framework test. We should only call methods in resources as needed. 