### PR TITLE
create added code to test mobile browser and mobile webview

### DIFF
--- a/Java/java-selenium/pom.xml
+++ b/Java/java-selenium/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>deque</groupId>
   <artifactId>java-selenium-axe-devtools</artifactId>
-  <version>4.7.1</version>
+  <version>4.10.0</version>
   <repositories>
     <repository>
       <id>deque</id>
@@ -19,11 +20,17 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
+    <!-- Appium Java Client -->
+    <dependency>
+      <groupId>io.appium</groupId>
+      <artifactId>java-client</artifactId>
+      <version>9.3.0</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -31,32 +38,51 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.11.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
+      <version>31.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.deque.html.axe-devtools</groupId>
       <artifactId>selenium</artifactId>
-      <version>4.9.0</version>
+      <version>4.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.1.3</version>
+      <version>4.27.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/io.github.bonigarcia/webdrivermanager -->
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>5.1.0</version>
+      <version>5.9.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20210307</version>
+    </dependency>
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>5.5.2</version>
+    </dependency>
+
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to
+      parent pom) -->
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <!-- clean lifecycle, see
+        https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
@@ -66,8 +92,28 @@
           <version>3.8.0</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>3.0.0-M5</version>
+          <configuration>
+            <systemPropertyVariables>
+              <PARALLELISM>20</PARALLELISM>
+              <MINIMUM_RUNNABLE>20</MINIMUM_RUNNABLE>
+              <MAX_POOL_SIZE>20</MAX_POOL_SIZE>
+              <CORE_POOL_SIZE>20</CORE_POOL_SIZE>
+            </systemPropertyVariables>
+            <properties>
+              <configurationParameters>
+                junit.jupiter.execution.parallel.enabled = true
+                junit.jupiter.execution.parallel.mode.default = concurrent
+                junit.jupiter.execution.parallel.mode.classes.default = concurrent
+                junit.jupiter.execution.parallel.config.strategy = fixed
+                junit.jupiter.execution.parallel.config.strategy = custom
+                junit.jupiter.execution.parallel.config.custom.class =
+                com.saucelabs.saucebindings.junit5.CustomStrategy
+              </configurationParameters>
+            </properties>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/Java/java-selenium/src/test/java/example/exampleTestMobileBrowserOnSauceEmuAndroid.java
+++ b/Java/java-selenium/src/test/java/example/exampleTestMobileBrowserOnSauceEmuAndroid.java
@@ -1,0 +1,128 @@
+package example;
+
+import com.deque.html.axecore.results.Results;
+import com.deque.html.axedevtools.selenium.AxeConfiguration;
+import com.deque.html.axedevtools.selenium.AxeDriver;
+import com.deque.html.axedevtools.selenium.AxeSelenium;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.openqa.selenium.By;
+import org.openqa.selenium.MutableCapabilities;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.android.AndroidDriver;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.deque.html.axedevtools.selenium.reporter.*;
+
+/**
+ * Accessibility Tests with Deque Library.
+ */
+public class exampleTestMobileBrowserOnSauceEmuAndroid {
+    public AppiumDriver driver;
+    private static AxeDriver axedriver = null;
+    private static AxeSelenium axeSelenium = null;
+    private static AxeReportingOptions _reportOptions = new AxeReportingOptions();
+
+    @RegisterExtension
+    public SauceTestWatcher watcher = new SauceTestWatcher();
+
+    @BeforeEach
+    public void setup(TestInfo testInfo) throws MalformedURLException {
+        axeSelenium = new AxeSelenium();
+        AxeConfiguration.configure().testSuiteName("Test").outputDirectory("axe-json-reports/");
+
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("platformName", "Android");
+        caps.setCapability("browserName", "Chrome");
+        // caps.setCapability("appium:deviceName", "Android GoogleAPI Emulator");
+        caps.setCapability("appium:deviceName", "Google.*");
+        caps.setCapability("appium:platformVersion", "15");
+        caps.setCapability("appium:automationName", "UiAutomator2");
+        MutableCapabilities sauceOptions = new MutableCapabilities();
+        // sauceOptions.setCapability("appiumVersion", "2.11.0");
+        sauceOptions.setCapability("appiumVersion", "latest");
+        sauceOptions.setCapability("username", System.getenv("SAUCE_USERNAME"));
+        sauceOptions.setCapability("accessKey", System.getenv("SAUCE_ACCESS_KEY"));
+        sauceOptions.setCapability("build", "mobile web build");
+        sauceOptions.setCapability("name", "mobile web test");
+        sauceOptions.setCapability("deviceOrientation", "PORTRAIT");
+        caps.setCapability("sauce:options", sauceOptions);
+
+        // Start the session
+        URL url = new URL("https://ondemand.eu-central-1.saucelabs.com:443/wd/hub");
+
+        try {
+            driver = new AndroidDriver(url, caps);
+            axedriver = new AxeDriver(driver);
+        } catch (Exception e) {
+            System.out.println("An Error Occurred creating the driver object: " + e);
+        }
+    }
+
+    @DisplayName("Recipe Homepage A11y Test")
+    @Test
+    public void test_a11y_workshop_homepage() {
+        driver.navigate().to("https://broken-workshop.dequelabs.com/");
+        Results accessibilityResults = axeSelenium.logResults(_reportOptions.uiState("Homepage_scan")).run(axedriver);
+        Assertions.assertEquals(3, accessibilityResults.getViolations().size());
+    }
+
+    @DisplayName("Recipe Card A11y Test")
+    @Test
+    public void test_recipe_card_a11y_workshop_homepage() {
+        driver.navigate().to("https://broken-workshop.dequelabs.com/");
+        driver
+                .findElement(
+                        By.cssSelector(
+                                "#main-content > div.Recipes > div:nth-child(1) > div.Recipes__card-foot > button"))
+                .click();
+        Results accessibilityResults = axeSelenium.logResults(_reportOptions.uiState("Recipe_card_scan"))
+                .run(axedriver);
+        Assertions.assertEquals(3, accessibilityResults.getViolations().size());
+    }
+
+    public class SauceTestWatcher implements TestWatcher {
+        @Override
+        public void testSuccessful(ExtensionContext context) {
+            driver.executeScript("sauce:job-result=passed");
+            driver.quit();
+        }
+
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            driver.executeScript("sauce:job-result=failed");
+            driver.quit();
+        }
+    }
+
+    @AfterAll
+    public static void reporting() throws IOException {
+        Runtime rt = Runtime.getRuntime();
+        String reporter = new File("src/test/resources/reporter-cli-macos").getAbsolutePath();
+        String Logger = new File("axe-json-reports/").getAbsolutePath();
+        String Destination = new File("a11y-results/").getAbsolutePath();
+        String command_xml = reporter + " " + Logger + " --destination " + Destination + " --format xml";
+        String command_html = reporter + " " + Logger + " --destination " + Destination + " --format html";
+        String command_csv = reporter + " " + Logger + " --destination " + Destination + " --format csv";
+        try {
+            rt.exec(command_html);
+            rt.exec(command_csv);
+            rt.exec(command_xml);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/Java/java-selenium/src/test/java/example/exampleTestMobileWebViewLocalEmuAndroid.java
+++ b/Java/java-selenium/src/test/java/example/exampleTestMobileWebViewLocalEmuAndroid.java
@@ -1,0 +1,223 @@
+package example;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.WebElement;
+
+import io.appium.java_client.android.AndroidDriver;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.FileWriter;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import java.time.Duration;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashMap;
+
+import org.json.JSONObject;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Accessibility Tests with Deque Library.
+ */
+public class exampleTestMobileWebViewLocalEmuAndroid {
+    public AndroidDriver driver;
+    private static Map<String, String> settings = null;
+    String directoryPath = "axe-json-reports";
+    String fileName;
+
+    @BeforeEach
+    public void setup(TestInfo testInfo) throws MalformedURLException {
+        String testApp = new File("src/test/resources/app/sauceDemo271.apk").getAbsolutePath();
+
+        MutableCapabilities caps = new MutableCapabilities();
+        caps.setCapability("appium:automationName", "AxeUiAutomator2");
+        caps.setCapability("appium:deviceName", "emulator-5554");
+        caps.setCapability("appium:orientation", "PORTRAIT");
+        caps.setCapability("appium:appPackage", "com.swaglabsmobileapp");
+        caps.setCapability("appium:app", testApp);
+        caps.setCapability("platformName", "Android");
+        caps.setCapability("appium:appWaitActivity", "com.swaglabsmobileapp.MainActivity");
+        // to facilitate webview testing
+        caps.setCapability("appium:chromedriver_autodownload", true);
+
+        // Start the session
+        URL url = new URL("http://127.0.0.1:4723/wd/hub");
+
+        try {
+            driver = new AndroidDriver(url, caps);
+            driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
+            settings = ImmutableMap.of("apiKey", System.getenv("AXE_MOBILE_API_KEY"));
+        } catch (Exception e) {
+            System.out.println("An Error Occurred creating the driver object: " + e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @DisplayName("Test Swag Labs")
+    @Test
+    public void swaglabs_app() throws InterruptedException {
+        // 1 - scan the home page
+        LinkedHashMap<String, Object> axeMobileResults = (LinkedHashMap<String, Object>) driver
+                .executeScript("mobile: axeScan", settings);
+        JSONObject mobileResults = new JSONObject(axeMobileResults);
+        String fileName = "axe-mobile-results-1.json";
+        saveJsonToFile(mobileResults, directoryPath, fileName);
+
+        // 2 - log in to the app
+        // 2.1 - enter the userid
+        WebElement el1 = driver.findElement(By.xpath("//android.widget.EditText[@content-desc='test-Username']"));
+        el1.sendKeys("standard_user");
+        el1 = null;
+
+        // 2.2 - enter the password
+        el1 = driver.findElement(By.xpath("//android.widget.EditText[@content-desc='test-Password']"));
+        el1.sendKeys("secret_sauce");
+        el1 = null;
+
+        // 2.3 - click the LOGIB button
+        el1 = driver.findElement(By.xpath("//android.widget.TextView[@text='LOGIN']"));
+        el1.click();
+        el1 = null;
+
+        // 3 - navigate the menu to navigate to the test webview page
+        // 3.1 0 click the hamburger menu
+        el1 = driver.findElement(By.xpath(
+                "//android.view.ViewGroup[@content-desc='test-Menu']/android.view.ViewGroup/android.widget.ImageView"));
+        el1.click();
+        el1 = null;
+
+        // 3.2 navigate to the WebView selection page
+        el1 = driver.findElement(By.xpath(
+                "//android.widget.TextView[@text='WEBVIEW']"));
+        el1.click();
+        el1 = null;
+
+        // 4 - enter the webpage to use for testing the webview
+        el1 = driver.findElement(By.xpath(
+                "//android.widget.EditText[contains(@content-desc,'test-enter')]"));
+        el1.sendKeys("www.saucedemo.com");
+        el1 = null;
+
+        // 5 - click 'GO TO SITE' to navigate to the page to test in the webview
+        el1 = driver.findElement(By.xpath("//android.widget.TextView[@text='GO TO SITE']"));
+        el1.click();
+        el1 = null;
+
+        // 6 - experimentally scan this page with mobile axe scanner
+        axeMobileResults = null;
+        axeMobileResults = (LinkedHashMap<String, Object>) driver.executeScript("mobile: axeScan", settings);
+        mobileResults = null;
+        mobileResults = new JSONObject(axeMobileResults);
+        fileName = "axe-mobile-results-2.json";
+        saveJsonToFile(mobileResults, directoryPath, fileName);
+
+        // 7 - now switch to the web context and use the web Axe scanner
+        // 7.1 - Get the available contexts
+        Set<String> contexts = driver.getContextHandles();
+        String webContext = "";
+        for (String context : contexts) {
+            System.out.println(context);
+            if (context.contains("WEBVIEW")) {
+                webContext = context;
+            }
+        }
+
+        // 7.2 Switch to the web context
+        driver.context(webContext);
+        // let's check to make sure the webview is really loaded
+        try {
+            el1 = driver.findElement(By.xpath("/html/body"));
+        } catch (Exception e) {
+            System.out.println("An Error Occurred finding element in webview: " + e);
+        }
+
+        // Run AXE accessibility tests
+
+        String script = "var script = document.createElement('script');"
+                + "script.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.0/axe.min.js';"
+                + "var callback = arguments[arguments.length - 1];"
+                + "script.onload = function () {"
+                + " axe.run("
+                + "    document,"
+                + "    {"
+                + "       runOnly: {"
+                + "         type: 'tag',"
+                + "         values: ['wcag2aaa', 'best-practice']"
+                + "       }"
+                + "    },"
+                + "    function (err, results) {"
+                + "      callback(JSON.stringify(results));"
+                + "    }"
+                + " );"
+                + "};"
+                + "document.head.appendChild(script);";
+
+        // Inject the JavaScript into the page and capture the results
+        String axeResults = (String) ((JavascriptExecutor) driver).executeAsyncScript(script);
+        // Parse the results into a JSONObject
+        JSONObject results = new JSONObject(axeResults);
+        // write the JSON results to the local filesystem
+        fileName = "axe-devtools-results-1.json";
+        // Save JSON to file
+        saveJsonToFile(results, directoryPath, fileName);
+
+        // Print the results
+        System.out.println(results.toString(2));
+
+        driver.context("NATIVE_APP");
+
+        Thread.sleep(10000);
+
+        driver.quit();
+    }
+
+    public static void saveJsonToFile(JSONObject jsonObject, String directoryPath, String fileName) {
+        // Create the directory if it doesn't exist
+        File directory = new File(directoryPath);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+
+        // Create the file
+        File file = new File(directoryPath + File.separator + fileName);
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            // Write the JSON object to the file
+            fileWriter.write(jsonObject.toString(2)); // Pretty print with an indentation of 2 spaces
+            System.out.println("JSON file created successfully at " + file.getAbsolutePath());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @AfterAll
+    public static void reporting() throws IOException {
+        Runtime rt = Runtime.getRuntime();
+        String reporter = new File("src/test/resources/reporter-cli-macos").getAbsolutePath();
+        String Logger = new File("axe-json-reports/").getAbsolutePath();
+        String Destination = new File("a11y-results/").getAbsolutePath();
+        String command_xml = reporter + " " + Logger + " --destination " + Destination + " --format xml";
+        String command_html = reporter + " " + Logger + " --destination " + Destination + " --format html";
+        String command_csv = reporter + " " + Logger + " --destination " + Destination + " --format csv";
+        try {
+            rt.exec(command_html);
+            rt.exec(command_csv);
+            rt.exec(command_xml);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
added 2 new classes:
exampleTestMobileBrowserOnSauceEmuAndroid.java
- this class is based on the original exampleTest.java class, but runs a test on a mobile device in Sauce Labs, inside a mobile browser.  Written from Android and Mobile Chrome.

exampleTestMobileWebViewLocalEmuAndroid.java
- this class uses the structure of the original exampleTest.java class but installs and launches a mobile application on a local android emulator.  The app is the Sauce Labs Swag Labs demo app as it has a hybrid test page (bundled in this repo) and the test launches the app, logs in and navigates to the hybrid page where the context is switched from NATIVE_APP to WEBVIEW and then the main Axe library is called to scan that element of the page.
- the same test also calls some native mobile axe scans (using the Deque AndroidDriver) and captures the results not only to the Mobile Dashoard, but also locally - rolling the results up to a common html report.